### PR TITLE
Fix bug when comparing "UNKNOWN" with "UNKNOWN\r".

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted to native line endings on checkout.
+*.c text eol=lf
+*.h text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.lst text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+LICENSE text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.dat binary
+*.bin binary
+*.exe binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # senna binary
 senna
+.vscode/
+*.exe
+*.bin

--- a/SENNA_Hash.c
+++ b/SENNA_Hash.c
@@ -25,9 +25,8 @@ SENNA_Hash* SENNA_Hash_new(const char *path, const char *filename)
   n_keys = 0;
   while(fgets(key, MAX_KEY_SIZE, f))
   {
-    int key_size = strlen(key);
-    key[key_size-1] = '\0'; /* discard the newline */
-    keys[n_keys] = SENNA_malloc(key_size, sizeof(char));
+    SENNA_trim(key); /* discard newline characters */
+    keys[n_keys] = SENNA_malloc(strlen(key) + 1, sizeof(char));
     strcpy(keys[n_keys], key);
     n_keys++;
   }

--- a/SENNA_utils.c
+++ b/SENNA_utils.c
@@ -220,3 +220,31 @@ void SENNA_print_tensor_2d(float *tensor, int nrow, int ncolumn)
   }
   printf("[Tensor of size %dx%d]\n", nrow, ncolumn);
 }
+
+char* SENNA_trim(char *str){
+  size_t countSpaces;
+  size_t i;
+
+  // Count spaces
+  for (countSpaces = 0; isspace(str[countSpaces]); countSpaces++);
+
+  // All spaces?
+  if(countSpaces == strlen(str)) {
+      str[0] = '\0';
+      return str;
+  }
+
+  // Trim leading space
+  for (i = countSpaces; str[i] != '\0'; i++) {
+      str[i - countSpaces] = str[i];
+  }
+  str[i - countSpaces] = '\0';
+
+  // Trim trailing space
+  for (i = strlen(str) - 1; i > 0 && isspace(str[i]); i--);
+  
+  // Write new null terminator character
+  str[i + 1] = '\0';
+
+  return str;
+}

--- a/SENNA_utils.h
+++ b/SENNA_utils.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <ctype.h>
 
 /* messaging */
 void SENNA_error(const char *fmt, ...);
@@ -29,5 +30,8 @@ void SENNA_free(void *ptr);
 /* debug */
 void SENNA_print_tensor_1d(float *tensor, int nrow);
 void SENNA_print_tensor_2d(float *tensor, int nrow, int ncolumn);
+
+/* string */
+char* SENNA_trim(char *str);
 
 #endif


### PR DESCRIPTION
Changes:
- Normalize all the line endings.
- **Fix bug**: msg "FATAL ERROR: could not find key UNKNOWN" when was comparing "UNKNOWN" with "UNKNOWN\r", i.e, when hash files (*.lst) ends with '\r\n' (CRLF) (newlines in Windows). **Solution**: trim each key read from hash files with function SENNA_trim(char *str).